### PR TITLE
feat: allow overriding proxy admin when deploy contract

### DIFF
--- a/script/BaseMigration.s.sol
+++ b/script/BaseMigration.s.sol
@@ -53,7 +53,7 @@ abstract contract BaseMigration is ScriptExtended {
     }
   }
 
-  function loadContract(TContract contractType) public virtual returns (address payable contractAddr) {
+  function loadContract(TContract contractType) public view virtual returns (address payable contractAddr) {
     return CONFIG.getAddressFromCurrentNetwork(contractType);
   }
 
@@ -67,7 +67,7 @@ abstract contract BaseMigration is ScriptExtended {
   }
 
   function _getProxyAdmin() internal view virtual returns (address payable proxyAdmin) {
-    proxyAdmin = CONFIG.getAddressFromCurrentNetwork(DefaultContract.ProxyAdmin.key());
+    proxyAdmin = loadContract(DefaultContract.ProxyAdmin.key());
   }
 
   function _deployImmutable(TContract contractType) internal virtual returns (address payable deployed) {


### PR DESCRIPTION
### Description
This PR mainly add internal function to enable overriding ProxyAdmin address when deployed TransparentUpgradeable Proxy. 
### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
