### PR TITLE
feat: allow forge script to handle loading `env` private key or `trezor` address & feature to sign wallet

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,16 +1,10 @@
 verify_arg=""
 extra_argument=""
-op_command="op run --env-file="./.env" --"
 
 for arg in "$@"; do
     case $arg in
     --trezor)
-        op_command=""
         extra_argument+=trezor@
-        ;;
-    --broadcast)
-        op_command="op run --env-file="./.env" --"
-        # verify_arg="--verify --verifier sourcify --verifier-url https://sourcify.roninchain.com/server/"
         ;;
     --log)
         set -- "${@/#--log/}"
@@ -24,4 +18,4 @@ done
 extra_argument="${extra_argument%%@}"
 
 calldata=$(cast calldata 'run()')
-${op_command} forge script ${verify_arg} --legacy ${@} --sig 'run(bytes,string)' ${calldata} "${extra_argument}"
+forge script ${verify_arg} ${@} -g 200 --sig 'run(bytes,string)' ${calldata} "${extra_argument}"

--- a/script/BaseGeneralConfig.sol
+++ b/script/BaseGeneralConfig.sol
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.19;
 
-import { Vm } from "../lib/forge-std/src/Vm.sol";
+import { Vm, VmSafe } from "../lib/forge-std/src/Vm.sol";
 import { StdStyle } from "../lib/forge-std/src/StdStyle.sol";
 import { console2 as console } from "../lib/forge-std/src/console2.sol";
-import { LibString } from "../lib/solady/src/utils/LibString.sol";
 import { WalletConfig } from "./configs/WalletConfig.sol";
 import { RuntimeConfig } from "./configs/RuntimeConfig.sol";
 import { MigrationConfig } from "./configs/MigrationConfig.sol";
@@ -17,10 +16,7 @@ import { LibSharedAddress } from "./libraries/LibSharedAddress.sol";
 
 contract BaseGeneralConfig is RuntimeConfig, WalletConfig, ContractConfig, NetworkConfig, MigrationConfig {
   using StdStyle for string;
-  using LibString for string;
   using EnumerableSet for EnumerableSet.AddressSet;
-
-  Vm internal constant vm = Vm(LibSharedAddress.VM);
 
   fallback() external {
     if (msg.sig == ISharedParameter.sharedArguments.selector) {
@@ -91,19 +87,12 @@ contract BaseGeneralConfig is RuntimeConfig, WalletConfig, ContractConfig, Netwo
   }
 
   function _setUpDefaultSender() private {
-    // by default we will read private key from .env
-    _envPk = vm.envUint(getPrivateKeyEnvLabel(getCurrentNetwork()));
-    _envSender = vm.rememberKey(_envPk);
-
-    label(block.chainid, _envSender, "ENVSender");
-    console.log("GeneralConfig:", vm.getLabel(_envSender));
-
     _setUpSender();
   }
 
   function getSender() public view virtual override returns (address payable sender) {
     sender = _option.trezor ? payable(_trezorSender) : payable(_envSender);
-    require(sender != address(0), "GeneralConfig: Sender is address(0x0)");
+    require(sender != address(0x0), "GeneralConfig: Sender is address(0x0)");
   }
 
   function setAddress(TNetwork network, TContract contractType, address contractAddr) public virtual {
@@ -127,10 +116,14 @@ contract BaseGeneralConfig is RuntimeConfig, WalletConfig, ContractConfig, Netwo
 
   function _handleRuntimeConfig() internal virtual override {
     if (_option.trezor) {
-      string memory str = vm.envString(deployerEnvLabel());
-      _trezorSender = vm.parseAddress(str.replace(trezorPrefix(), ""));
+      _loadTrezorAccount();
       label(block.chainid, _trezorSender, "TrezorSender");
-      console.log("GeneralConfig:", vm.getLabel(_trezorSender));
+      console.log("GeneralConfig:", vm.getLabel(_trezorSender), "Enabled!");
+    } else {
+      string memory envLabel = getPrivateKeyEnvLabel(getCurrentNetwork());
+      _loadENVAccount(envLabel);
+      label(block.chainid, _envSender, "ENVSender");
+      console.log("GeneralConfig:", vm.getLabel(_envSender), "Enabled!");
     }
   }
 }

--- a/script/configs/WalletConfig.sol
+++ b/script/configs/WalletConfig.sol
@@ -1,18 +1,19 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.19;
 
+import { CommonBase } from "../../lib/forge-std/src/Base.sol";
+import { LibString } from "../../lib/solady/src/utils/LibString.sol";
 import { IWalletConfig } from "../interfaces/configs/IWalletConfig.sol";
 
-abstract contract WalletConfig is IWalletConfig {
-  uint256 internal _envPk;
+abstract contract WalletConfig is CommonBase, IWalletConfig {
+  using LibString for string;
+
+  string internal _envLabel;
   address internal _envSender;
   address internal _trezorSender;
+  WalletOption internal _walletOption;
 
   function getSender() public view virtual returns (address payable sender);
-
-  function getSenderPk() public view virtual returns (uint256) {
-    return _envPk;
-  }
 
   function trezorPrefix() public view virtual returns (string memory) {
     return "trezor://";
@@ -20,5 +21,57 @@ abstract contract WalletConfig is IWalletConfig {
 
   function deployerEnvLabel() public view virtual returns (string memory) {
     return "DEPLOYER";
+  }
+
+  function _loadTrezorAccount() internal {
+    if (tx.origin != DEFAULT_SENDER) {
+      _trezorSender = tx.origin;
+    } else {
+      try vm.envString(deployerEnvLabel()) returns (string memory str) {
+        _trezorSender = vm.parseAddress(str.replace(trezorPrefix(), ""));
+      } catch {
+        revert(
+          string.concat(
+            "\nGeneralConfig: Error finding trezor address!\n- Please override default sender with `--sender {your_trezor_account}` tag \n- Or make `.env` file and create field `",
+            deployerEnvLabel(),
+            "=",
+            trezorPrefix(),
+            "{your_trezor_account}`"
+          )
+        );
+      }
+    }
+    _walletOption = WalletOption.Trezor;
+  }
+
+  function _loadENVAccount(string memory envLabel) internal {
+    _envLabel = envLabel;
+    _walletOption = WalletOption.Env;
+    _envSender = vm.rememberKey(_loadENVPrivateKey(envLabel));
+  }
+
+  function _loadENVPrivateKey(string memory envLabel) private returns (uint256) {
+    try vm.envUint(envLabel) returns (uint256 pk) {
+      return pk;
+    } catch {
+      string[] memory commandInput = new string[](3);
+
+      try vm.envString(envLabel) returns (string memory data) {
+        commandInput[2] = data;
+      } catch {
+        revert(
+          string.concat(
+            "\nGeneralConfig: Error finding env address!\n- Please make `.env` file and create field `",
+            envLabel,
+            "=",
+            "{op_secret_reference_or_your_private_key}`"
+          )
+        );
+      }
+      commandInput[0] = "op";
+      commandInput[1] = "read";
+
+      return vm.parseUint(vm.toString(vm.ffi(commandInput)));
+    }
   }
 }

--- a/script/interfaces/configs/IWalletConfig.sol
+++ b/script/interfaces/configs/IWalletConfig.sol
@@ -2,7 +2,10 @@
 pragma solidity ^0.8.19;
 
 interface IWalletConfig {
-  function getSenderPk() external view returns (uint256);
+  enum WalletOption {
+    Env,
+    Trezor
+  }
 
   function getSender() external view returns (address payable sender);
 

--- a/script/interfaces/configs/IWalletConfig.sol
+++ b/script/interfaces/configs/IWalletConfig.sol
@@ -12,4 +12,28 @@ interface IWalletConfig {
   function trezorPrefix() external view returns (string memory);
 
   function deployerEnvLabel() external view returns (string memory);
+
+  function ethSignMessage(address by, string memory message, WalletOption walletOption)
+    external
+    returns (bytes memory sig);
+
+  function ethSignMessage(string memory message) external returns (bytes memory sig);
+
+  function envEthSignMessage(address by, string memory message, string memory envLabel)
+    external
+    returns (bytes memory sig);
+
+  function envSignTypedDataV4(address by, string memory filePath, string memory envLabel)
+    external
+    returns (bytes memory sig);
+
+  function trezorEthSignMessage(address by, string memory message) external returns (bytes memory sig);
+
+  function trezorSignTypedDataV4(address by, string memory filePath) external returns (bytes memory sig);
+
+  function signTypedDataV4(address by, string memory filePath, WalletOption walletOption)
+    external
+    returns (bytes memory sig);
+
+  function signTypedDataV4(string memory filePath) external returns (bytes memory sig);
 }


### PR DESCRIPTION
### Description
This PR provides new features:
#### Fix bad UX when using `--trezor` flag by:
- disallow loading ENV private key by default when enable `--trezor`.
- revert with clearer error when project repository not create `.env` file
- when using `--trezor`, `.env` file is not required, trezor address can be provided with tags `--sender`
#### Expose signing interfaces for wallet:
- Feature to sign `EthSignMessage` with string `message`.
- Feature to sign TypedDataV4 with file path to <path/typed_data.json>

### Example
Run script with trezor wallet
```shell
$ ./run.sh Migration -f <network> --trezor --from <your_trezor_account>
``` 
 
### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
