### PR TITLE
feat: support default sender for test integration

### DIFF
--- a/script/BaseGeneralConfig.sol
+++ b/script/BaseGeneralConfig.sol
@@ -76,11 +76,18 @@ contract BaseGeneralConfig is RuntimeConfig, WalletConfig, ContractConfig, Netwo
 
   function _setUpDefaultContracts() private {
     _contractNameMap[DefaultContract.ProxyAdmin.key()] = DefaultContract.ProxyAdmin.name();
+    _contractNameMap[DefaultContract.Multicall3.key()] = DefaultContract.Multicall3.name();
     setAddress(
       DefaultNetwork.RoninTestnet.key(), DefaultContract.ProxyAdmin.key(), 0x505d91E8fd2091794b45b27f86C045529fa92CD7
     );
     setAddress(
       DefaultNetwork.RoninMainnet.key(), DefaultContract.ProxyAdmin.key(), 0xA3e7d085E65CB0B916f6717da876b7bE5cC92f03
+    );
+    setAddress(
+      DefaultNetwork.RoninMainnet.key(), DefaultContract.Multicall3.key(), 0xcA11bde05977b3631167028862bE2a173976CA11
+    );
+    setAddress(
+      DefaultNetwork.RoninTestnet.key(), DefaultContract.Multicall3.key(), 0xcA11bde05977b3631167028862bE2a173976CA11
     );
 
     _setUpContracts();
@@ -92,6 +99,7 @@ contract BaseGeneralConfig is RuntimeConfig, WalletConfig, ContractConfig, Netwo
 
   function getSender() public view virtual override returns (address payable sender) {
     sender = _option.trezor ? payable(_trezorSender) : payable(_envSender);
+    if (sender == address(0x0) && getCurrentNetwork() == DefaultNetwork.Local.key()) sender = payable(DEFAULT_SENDER);
     require(sender != address(0x0), "GeneralConfig: Sender is address(0x0)");
   }
 

--- a/script/BaseMigration.s.sol
+++ b/script/BaseMigration.s.sol
@@ -27,8 +27,7 @@ abstract contract BaseMigration is ScriptExtended {
 
   function setUp() public virtual override {
     super.setUp();
-    vm.label(address(ARTIFACT_FACTORY), "ArtifactFactory");
-    deploySharedAddress(address(ARTIFACT_FACTORY), type(ArtifactFactory).creationCode);
+    deploySharedAddress(address(ARTIFACT_FACTORY), type(ArtifactFactory).creationCode, "ArtifactFactory");
     _injectDependencies();
     _storeRawSharedArguments();
   }
@@ -66,7 +65,7 @@ abstract contract BaseMigration is ScriptExtended {
     args = _overriddenArgs.length == 0 ? _defaultArguments() : _overriddenArgs;
   }
 
-  function _getProxyAdmin() internal view virtual returns (address payable proxyAdmin) {
+  function _getProxyAdmin() internal virtual returns (address payable proxyAdmin) {
     proxyAdmin = loadContract(DefaultContract.ProxyAdmin.key());
   }
 

--- a/script/configs/WalletConfig.sol
+++ b/script/configs/WalletConfig.sol
@@ -41,6 +41,10 @@ abstract contract WalletConfig is CommonBase, IWalletConfig {
     public
     returns (bytes memory sig)
   {
+    sig = ethSignMessage(by, message, _loadENVPrivateKey(envLabel));
+  }
+
+  function ethSignMessage(address by, string memory message, uint256 privateKey) public returns (bytes memory sig) {
     string[] memory commandInput = new string[](8);
     commandInput[0] = "cast";
     commandInput[1] = "wallet";
@@ -48,7 +52,7 @@ abstract contract WalletConfig is CommonBase, IWalletConfig {
     commandInput[3] = "--from";
     commandInput[4] = vm.toString(by);
     commandInput[5] = "--private-key";
-    commandInput[6] = LibString.toHexString(_loadENVPrivateKey(envLabel));
+    commandInput[6] = LibString.toHexString(privateKey);
     commandInput[7] = message;
 
     sig = vm.ffi(commandInput);
@@ -86,6 +90,10 @@ abstract contract WalletConfig is CommonBase, IWalletConfig {
     public
     returns (bytes memory sig)
   {
+    sig = signTypedDataV4(by, filePath, _loadENVPrivateKey(envLabel));
+  }
+
+  function signTypedDataV4(address by, string memory filePath, uint256 privateKey) public returns (bytes memory sig) {
     string[] memory commandInput = new string[](10);
     commandInput[0] = "cast";
     commandInput[1] = "wallet";
@@ -93,7 +101,7 @@ abstract contract WalletConfig is CommonBase, IWalletConfig {
     commandInput[3] = "--from";
     commandInput[4] = vm.toString(by);
     commandInput[5] = "--private-key";
-    commandInput[6] = LibString.toHexString(_loadENVPrivateKey(envLabel));
+    commandInput[6] = LibString.toHexString(privateKey);
     commandInput[7] = "--data";
     commandInput[8] = "--from-file";
     commandInput[9] = filePath;

--- a/script/extensions/ScriptExtended.s.sol
+++ b/script/extensions/ScriptExtended.s.sol
@@ -32,9 +32,12 @@ abstract contract ScriptExtended is Script, StdAssertions, IScriptExtended {
     _swichBack(currentNetwork);
   }
 
+  constructor() {
+    setUp();
+  }
+
   function setUp() public virtual {
-    vm.label(address(CONFIG), "GeneralConfig");
-    deploySharedAddress(address(CONFIG), _configByteCode());
+    deploySharedAddress(address(CONFIG), _configByteCode(), "GeneralConfig");
   }
 
   function _configByteCode() internal virtual returns (bytes memory);
@@ -65,17 +68,18 @@ abstract contract ScriptExtended is Script, StdAssertions, IScriptExtended {
     revert("ScriptExtended: Got failed assertion");
   }
 
-  function deploySharedAddress(address where, bytes memory bytecode) public {
+  function deploySharedAddress(address where, bytes memory bytecode, string memory label) public {
     if (where.code.length == 0) {
       vm.makePersistent(where);
       vm.allowCheatcodes(where);
       deployCodeTo(bytecode, where);
+      if (bytes(label).length != 0) vm.label(where, label);
     }
   }
 
   function deploySharedMigration(TContract contractType, bytes memory bytecode) public returns (address where) {
     where = address(ripemd160(abi.encode(contractType)));
-    deploySharedAddress(where, bytecode);
+    deploySharedAddress(where, bytecode, string.concat(contractType.contractName(), "Deploy"));
   }
 
   function deployCodeTo(bytes memory creationCode, address where) internal {

--- a/script/interfaces/configs/IWalletConfig.sol
+++ b/script/interfaces/configs/IWalletConfig.sol
@@ -19,6 +19,8 @@ interface IWalletConfig {
 
   function ethSignMessage(string memory message) external returns (bytes memory sig);
 
+  function ethSignMessage(address by, string memory message, uint256 privateKey) external returns (bytes memory sig);
+
   function envEthSignMessage(address by, string memory message, string memory envLabel)
     external
     returns (bytes memory sig);
@@ -30,6 +32,8 @@ interface IWalletConfig {
   function trezorEthSignMessage(address by, string memory message) external returns (bytes memory sig);
 
   function trezorSignTypedDataV4(address by, string memory filePath) external returns (bytes memory sig);
+
+  function signTypedDataV4(address by, string memory filePath, uint256 privateKey) external returns (bytes memory sig);
 
   function signTypedDataV4(address by, string memory filePath, WalletOption walletOption)
     external

--- a/script/utils/DefaultContract.sol
+++ b/script/utils/DefaultContract.sol
@@ -5,7 +5,8 @@ import { LibString } from "../../lib/solady/src/utils/LibString.sol";
 import { TContract } from "../types/Types.sol";
 
 enum DefaultContract {
-  ProxyAdmin
+  ProxyAdmin,
+  Multicall3
 }
 
 using { key, name } for DefaultContract global;
@@ -16,5 +17,6 @@ function key(DefaultContract defaultContract) pure returns (TContract) {
 
 function name(DefaultContract defaultContract) pure returns (string memory) {
   if (defaultContract == DefaultContract.ProxyAdmin) return "ProxyAdmin";
+  if (defaultContract == DefaultContract.Multicall3) return "Multicall3";
   revert("DefaultContract: Unknown contract");
 }


### PR DESCRIPTION
### Description
This PR supports default sender for anvil run and unit tests, add default multicall address for `ronin-mainnet`, `ronin-testnet` and minor improvement in WalletConfig.

### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
](feat: support default sender for test integration)