### PR TITLE
feat: build raw shared argument once

### DIFF
--- a/script/BaseMigration.s.sol
+++ b/script/BaseMigration.s.sol
@@ -33,6 +33,7 @@ abstract contract BaseMigration is ScriptExtended {
   }
 
   function _storeRawSharedArguments() internal virtual {
+    if (CONFIG.areSharedArgumentsStored()) return;
     CONFIG.setRawSharedArguments(_sharedArguments());
   }
 

--- a/script/configs/MigrationConfig.sol
+++ b/script/configs/MigrationConfig.sol
@@ -7,8 +7,12 @@ abstract contract MigrationConfig is IMigrationConfig {
   bytes internal _migrationConfig;
 
   function setRawSharedArguments(bytes memory config) public virtual {
-    if (_migrationConfig.length != 0) return;
+    if (areSharedArgumentsStored()) return;
     _migrationConfig = config;
+  }
+
+  function areSharedArgumentsStored() public view virtual returns (bool) {
+    return _migrationConfig.length != 0;
   }
 
   function getRawSharedArguments() public view virtual returns (bytes memory) {

--- a/script/interfaces/configs/IMigrationConfig.sol
+++ b/script/interfaces/configs/IMigrationConfig.sol
@@ -2,6 +2,8 @@
 pragma solidity ^0.8.19;
 
 interface IMigrationConfig {
+  function areSharedArgumentsStored() external view returns (bool);
+
   function setRawSharedArguments(bytes calldata migrationConfig) external;
 
   function getRawSharedArguments() external view returns (bytes memory);


### PR DESCRIPTION
### Description
This feature disallow building raw shared argument via `_sharedArgument` multiple times.
### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
