### PR TITLE
fix(BaseMigration): reorder inner call to avoid bugs

### DIFF
--- a/script/BaseMigration.s.sol
+++ b/script/BaseMigration.s.sol
@@ -27,9 +27,9 @@ abstract contract BaseMigration is ScriptExtended {
 
   function setUp() public virtual override {
     super.setUp();
-    deploySharedAddress(address(ARTIFACT_FACTORY), type(ArtifactFactory).creationCode, "ArtifactFactory");
-    _injectDependencies();
     _storeRawSharedArguments();
+    _injectDependencies();
+    deploySharedAddress(address(ARTIFACT_FACTORY), type(ArtifactFactory).creationCode, "ArtifactFactory");
   }
 
   function _storeRawSharedArguments() internal virtual {


### PR DESCRIPTION
### Description
This PR simply reorder inner call in BaseMigration constructor to avoid bugs
### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
