### PR TITLE
feat: deploy transparent proxy using new keyword.

### DIFF
--- a/script/BaseMigration.s.sol
+++ b/script/BaseMigration.s.sol
@@ -119,11 +119,12 @@ abstract contract BaseMigration is ScriptExtended {
 
     address logic = _deployLogic(contractType);
     string memory proxyAbsolutePath = "TransparentUpgradeableProxy.sol:TransparentUpgradeableProxy";
-    uint256 proxyNonce;
+    uint256 proxyNonce = vm.getNonce(sender());
     address proxyAdmin = _getProxyAdmin();
     assertTrue(proxyAdmin != address(0x0), "BaseMigration: Null ProxyAdmin");
 
-    (deployed, proxyNonce) = _deployRaw(proxyAbsolutePath, abi.encode(logic, proxyAdmin, args));
+    vm.broadcast(sender());
+    deployed = payable(address(new TransparentUpgradeableProxy(logic, proxyAdmin, args)));
 
     // validate proxy admin
     address actualProxyAdmin = deployed.getProxyAdmin();


### PR DESCRIPTION
### Description

Fixed the version of OZ is 4.9.5 when deploying TransparentUpgradableProxy contract. 

### Checklist
- [ ] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [ ] The box that allows repo maintainers to update this PR is checked
- [ ] I tested locally to make sure this feature/fix works
