### PR TITLE
feat: add minor utility functions and rename variables

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -6,8 +6,8 @@ for arg in "$@"; do
     --trezor)
         extra_argument+=trezor@
         ;;
-    --disable-postcheck)
-        set -- "${@/#--disable-postcheck/}"
+    --no-postcheck)
+        set -- "${@/#--no-postcheck/}"
         extra_argument+=no-postcheck@
         ;;
     --generate-artifacts)

--- a/script/BaseMigration.s.sol
+++ b/script/BaseMigration.s.sol
@@ -2,10 +2,7 @@
 pragma solidity ^0.8.19;
 
 import { ProxyAdmin } from "../lib/openzeppelin-contracts/contracts/proxy/transparent/ProxyAdmin.sol";
-import {
-  ITransparentUpgradeableProxy,
-  TransparentUpgradeableProxy
-} from "../lib/openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import { ITransparentUpgradeableProxy, Proxy } from "../src/Proxy.sol";
 import { LibString } from "../lib/solady/src/utils/LibString.sol";
 import {
   console,
@@ -139,13 +136,13 @@ abstract contract BaseMigration is ScriptExtended {
     string memory contractName = CONFIG.getContractName(contractType);
 
     address logic = _deployLogic(contractType, argsLogicConstructor);
-    string memory proxyAbsolutePath = "TransparentUpgradeableProxy.sol:TransparentUpgradeableProxy";
+    string memory proxyAbsolutePath = "Proxy.sol:Proxy";
     uint256 proxyNonce = vm.getNonce(sender());
     address proxyAdmin = _getProxyAdmin();
     assertTrue(proxyAdmin != address(0x0), "BaseMigration: Null ProxyAdmin");
 
     vm.broadcast(sender());
-    deployed = payable(address(new TransparentUpgradeableProxy(logic, proxyAdmin, args)));
+    deployed = payable(address(new Proxy(logic, proxyAdmin, args)));
 
     // validate proxy admin
     address actualProxyAdmin = deployed.getProxyAdmin();

--- a/src/Proxy.sol
+++ b/src/Proxy.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import {
+  ITransparentUpgradeableProxy,
+  TransparentUpgradeableProxy
+} from "../lib/openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+
+/**
+ * @title Proxy
+ * @dev A contract that acts as a proxy for transparent upgrades.
+ */
+contract Proxy is TransparentUpgradeableProxy {
+  /**
+   * @dev Initializes the Proxy contract.
+   * @param _logic The address of the logic contract.
+   * @param _admin The address of the admin contract.
+   * @param _data The initialization data.
+   */
+  constructor(address _logic, address _admin, bytes memory _data) TransparentUpgradeableProxy(_logic, _admin, _data) { }
+}


### PR DESCRIPTION
### Description
This PR adds following features:
- Rename `TransparentUpgradeableProxy` into `Proxy` for parent directory applies different version of @openzeppelin
- Rename `--disable-postcheck` flags to `--no-postcheck`
- Add `_cheatBroadcast` function to log function call and prank as sender.

### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
