### PR TITLE
fix: update visibility of upgrade callback

### DIFF
--- a/script/BaseMigration.s.sol
+++ b/script/BaseMigration.s.sol
@@ -30,13 +30,13 @@ abstract contract BaseMigration is ScriptExtended {
     _injectDependencies();
   }
 
-  function upgradeCallback(
+  function _upgradeCallback(
     address, /* proxy */
     address, /* logic */
     uint256, /* callValue */
     bytes memory, /* callData */
     ProxyInterface /* proxyInterface */
-  ) external virtual { }
+  ) internal virtual { }
 
   function _sharedArguments() internal virtual returns (bytes memory rawSharedArgs);
 
@@ -271,7 +271,7 @@ abstract contract BaseMigration is ScriptExtended {
       callData: args,
       shouldPrompt: true,
       proxyInterface: ProxyInterface.Transparent,
-      upgradeCallback: this.upgradeCallback,
+      upgradeCallback: _upgradeCallback,
       shouldUseCallback: false
     }).upgrade();
   }

--- a/script/libraries/LibDeploy.sol
+++ b/script/libraries/LibDeploy.sol
@@ -32,7 +32,7 @@ struct UpgradeInfo {
   uint256 callValue;
   bytes callData;
   ProxyInterface proxyInterface;
-  function(address,address,uint256,bytes memory,ProxyInterface) external upgradeCallback;
+  function(address,address,uint256,bytes memory,ProxyInterface) internal upgradeCallback;
   bool shouldUseCallback;
   bool shouldPrompt;
 }
@@ -120,7 +120,7 @@ library LibDeploy {
     uint256 callValue,
     bytes memory callData,
     bool shouldPrompt,
-    function(address,address,uint256,bytes memory,ProxyInterface) external upgradeCallback,
+    function(address,address,uint256,bytes memory,ProxyInterface) internal upgradeCallback,
     bool shouldUseCallback
   ) internal validateUpgrade(proxy, logic, shouldPrompt) {
     if (shouldUseCallback) {

--- a/test/LibDeploy.t.sol
+++ b/test/LibDeploy.t.sol
@@ -31,7 +31,7 @@ contract LibDeployTest is Test {
       callValue: 0,
       callData: abi.encodeCall(MockERC721.initialize, ("Name", "Symbol")),
       proxyInterface: ProxyInterface.Transparent,
-      upgradeCallback: this.emptyFn,
+      upgradeCallback: emptyFn,
       shouldPrompt: false,
       shouldUseCallback: false
     });
@@ -56,7 +56,7 @@ contract LibDeployTest is Test {
       callValue: 0,
       callData: abi.encodeCall(MockERC20.initialize, ("Name", "Symbol", 18)),
       proxyInterface: ProxyInterface.Transparent,
-      upgradeCallback: this.emptyFn,
+      upgradeCallback: emptyFn,
       shouldPrompt: false,
       shouldUseCallback: false
     });
@@ -79,7 +79,7 @@ contract LibDeployTest is Test {
       callValue: 0,
       callData: abi.encodeCall(MockERC20.initialize, ("Name", "Symbol", 18)),
       proxyInterface: ProxyInterface.Transparent,
-      upgradeCallback: this.emptyFn,
+      upgradeCallback: emptyFn,
       shouldPrompt: false,
       shouldUseCallback: false
     });
@@ -108,7 +108,7 @@ contract LibDeployTest is Test {
       callValue: 0,
       callData: abi.encodeCall(MockERC20.initialize, ("Name", "Symbol", 18)),
       proxyInterface: ProxyInterface.Transparent,
-      upgradeCallback: this.emptyFn,
+      upgradeCallback: emptyFn,
       shouldPrompt: false,
       shouldUseCallback: false
     });
@@ -122,5 +122,5 @@ contract LibDeployTest is Test {
     uint256, /* callValue */
     bytes memory, /* callData */
     ProxyInterface /* proxyInterface */
-  ) external { }
+  ) internal { }
 }


### PR DESCRIPTION
### Description

The visibility of the upgrade callback should be set to internal to allow derived contracts to inherit and call super. if needed. An external method cannot achieve this.

### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
