### PR TITLE
feat: log Safe EIP-712 tx hashes on cheat broadcast

### DIFF
--- a/script/utils/Helpers.sol
+++ b/script/utils/Helpers.sol
@@ -246,7 +246,6 @@ function cheatBroadcast(address from, address to, uint256 callValue, bytes memor
 
   logSafeTxHashes({ safe: from, to: to, value: callValue, data: callData });
 
-
   vm.prank(from);
   (bool success, bytes memory returnOrRevertData) = to.call{ value: callValue }(callData);
   success.handleRevert(bytes4(callData), returnOrRevertData);

--- a/script/utils/Helpers.sol
+++ b/script/utils/Helpers.sol
@@ -246,7 +246,6 @@ function cheatBroadcast(address from, address to, uint256 callValue, bytes memor
 
   logSafeTxHashes({ safe: from, to: to, value: callValue, data: callData });
 
-  logSafeTxHashes({ safe: from, to: to, value: callValue, data: callData });
 
   vm.prank(from);
   (bool success, bytes memory returnOrRevertData) = to.call{ value: callValue }(callData);

--- a/script/utils/Helpers.sol
+++ b/script/utils/Helpers.sol
@@ -87,6 +87,128 @@ function logInnerCall(
   console.log("> ", fnName.blue(), "...");
 }
 
+// keccak256("EIP712Domain(uint256 chainId,address verifyingContract)")
+bytes32 constant SAFE_DOMAIN_SEPARATOR_TYPEHASH = 0x47e79534a245952e8b16893a336b85a3d9ea9fa8c573f3d803afb92a79469218;
+// keccak256("SafeTx(address to,uint256 value,bytes data,uint8 operation,uint256 safeTxGas,uint256 baseGas,uint256
+// gasPrice,address gasToken,address refundReceiver,uint256 nonce)")
+bytes32 constant SAFE_TX_TYPEHASH = 0xbb8310d486368db6bd6f849402fdd73ad53d316b5a4b2644ad6efe0f941286d8;
+// Sentinel for "no SAFE_NONCE override supplied".
+uint256 constant SAFE_NONCE_UNSET = type(uint256).max;
+
+/// @dev Returns true when `account` looks like a Safe wallet (exposes the Safe-specific `getThreshold()`).
+function _isSafeWallet(
+  address account
+) view returns (bool) {
+  (bool ok, bytes memory ret) = account.staticcall(abi.encodeWithSignature("getThreshold()"));
+  return ok && ret.length >= 32 && abi.decode(ret, (uint256)) != 0;
+}
+
+/// @dev Safe Transaction Service base URL for `chainId`, or "" when unknown. The `SAFE_TX_SERVICE_URL` env var,
+/// when set, overrides the built-in mapping (useful for self-hosted services or unlisted chains).
+function _safeTxServiceBaseUrl(
+  uint256 chainId
+) view returns (string memory) {
+  string memory fromEnv = vm.envOr("SAFE_TX_SERVICE_URL", string(""));
+  if (bytes(fromEnv).length != 0) return fromEnv;
+  if (chainId == 2020) return "https://safe-transaction-ronin.safe.onchainden.com"; // Ronin mainnet
+  return "";
+}
+
+/// @dev Best-effort fetch of the next nonce from the Safe Transaction Service, which is queue-aware (it accounts
+/// for proposed-but-not-yet-executed transactions). Returns (false, 0) when the service is unknown/unreachable or
+/// the Safe is not indexed there, so the caller can fall back to the on-chain nonce.
+function _tryGetSafeApiNonce(
+  address safe
+) returns (bool ok, uint256 nonce) {
+  string memory baseUrl = _safeTxServiceBaseUrl(block.chainid);
+  if (bytes(baseUrl).length == 0) return (false, 0);
+
+  // The service requires an EIP-55 checksummed address; a lowercase address is rejected with HTTP 422.
+  string memory url = string.concat(baseUrl, "/api/v1/safes/", safe.toHexStringChecksummed(), "/");
+  string[] memory cmd = new string[](3);
+  cmd[0] = "curl";
+  cmd[1] = "-sf"; // -s: silent; -f: exit non-zero on HTTP >= 400 so `vm.ffi` reverts and we fall back
+  cmd[2] = url;
+
+  try vm.ffi(cmd) returns (bytes memory res) {
+    // Body looks like {"address":"0x..","nonce":"318",...}. The leading '{' keeps `vm.ffi` from mis-decoding
+    // the output as hex and guards JSONParserLib against a non-JSON 200 response.
+    if (res.length == 0 || res[0] != bytes1("{")) return (false, 0);
+    string memory raw = string(res).parse().at('"nonce"').value(); // e.g. "\"318\""
+    if (bytes(raw).length == 0) return (false, 0);
+    return (true, JSONParserLib.parseUint(JSONParserLib.decodeString(raw)));
+  } catch {
+    return (false, 0);
+  }
+}
+
+/// @dev Resolves the Safe nonce used for hash computation, highest priority first:
+///   1. `SAFE_NONCE` env var — overwrite an existing/queued nonce (e.g. to co-sign a specific pending tx)
+///   2. Safe Transaction Service `nonce` (queue-aware)
+///   3. on-chain `Safe.nonce()`
+/// `safe` is assumed to be a Safe wallet, so the on-chain fallback always succeeds.
+function _resolveSafeNonce(
+  address safe
+) returns (uint256 nonce, string memory source) {
+  uint256 overrideNonce = vm.envOr("SAFE_NONCE", SAFE_NONCE_UNSET);
+  if (overrideNonce != SAFE_NONCE_UNSET) return (overrideNonce, "overwrite (env SAFE_NONCE)");
+
+  (bool apiOk, uint256 apiNonce) = _tryGetSafeApiNonce(safe);
+  if (apiOk) return (apiNonce, "safe-tx-service api");
+
+  (, bytes memory ret) = safe.staticcall(abi.encodeWithSignature("nonce()"));
+  return (abi.decode(ret, (uint256)), "onchain nonce()");
+}
+
+/// @dev Pure EIP-712 hash computation for a Safe `execTransaction` with the standard defaults used by the Safe UI
+/// for a simple call (operation = CALL, all gas/refund params zeroed). Assumes Safe version >= 1.3.0 (domain
+/// separator includes `chainId`). Returns the domain separator, the SafeTx message hash, and the final Safe tx hash.
+function computeSafeTxHashes(
+  uint256 chainId,
+  address safe,
+  address to,
+  uint256 value,
+  bytes memory data,
+  uint256 nonce
+) pure returns (bytes32 domainHash, bytes32 messageHash, bytes32 safeTxHash) {
+  domainHash = keccak256(abi.encode(SAFE_DOMAIN_SEPARATOR_TYPEHASH, chainId, safe));
+  messageHash = keccak256(
+    abi.encode(
+      SAFE_TX_TYPEHASH,
+      to,
+      value,
+      keccak256(data),
+      uint8(0), // operation: CALL
+      uint256(0), // safeTxGas
+      uint256(0), // baseGas
+      uint256(0), // gasPrice
+      address(0), // gasToken
+      address(0), // refundReceiver
+      nonce
+    )
+  );
+  safeTxHash = keccak256(abi.encodePacked(bytes1(0x19), bytes1(0x01), domainHash, messageHash));
+}
+
+/// @dev Computes and logs the Safe (Gnosis Safe) EIP-712 hashes for the pending transaction so signers can
+/// independently verify them (e.g. with `axieinfinity/safe-utils`, the Safe UI, or a hardware wallet) before signing.
+/// Silently returns when `safe` is not a Safe wallet. See `_resolveSafeNonce` for the nonce priority.
+function logSafeTxHashes(address safe, address to, uint256 value, bytes memory data) {
+  if (!_isSafeWallet(safe)) return;
+  (uint256 nonce, string memory nonceSource) = _resolveSafeNonce(safe);
+
+  (bytes32 domainHash, bytes32 messageHash, bytes32 safeTxHash) =
+    computeSafeTxHashes(block.chainid, safe, to, value, data, nonce);
+
+  console.log(StdStyle.yellow("------------------------- Safe Tx Hashes -------------------------"));
+  console.log(StdStyle.cyan("Safe:"), vm.getLabel(safe));
+  console.log(StdStyle.cyan("Nonce:"), string.concat(vm.toString(nonce), "  (source: ", nonceSource, ")"));
+  console.log(StdStyle.cyan("Domain Hash:"), vm.toString(domainHash));
+  console.log(StdStyle.cyan("Message Hash:"), vm.toString(messageHash));
+  console.log(StdStyle.cyan("Safe Tx Hash:"), vm.toString(safeTxHash));
+  console.log("--------------------------------------------------------------------");
+}
+
 function cheatBroadcast(address from, address to, uint256 callValue, bytes memory callData) {
   string[] memory commandInputs = new string[](3);
   commandInputs[0] = "cast";
@@ -105,6 +227,8 @@ function cheatBroadcast(address from, address to, uint256 callValue, bytes memor
   );
   console.log(StdStyle.cyan("Cast Decoded Call Data:"), decodedCallData);
   console.log("--------------------------------------------------------------------");
+
+  logSafeTxHashes({ safe: from, to: to, value: callValue, data: callData });
 
   vm.prank(from);
   (bool success, bytes memory returnOrRevertData) = to.call{ value: callValue }(callData);

--- a/script/utils/Helpers.sol
+++ b/script/utils/Helpers.sol
@@ -95,12 +95,25 @@ bytes32 constant SAFE_TX_TYPEHASH = 0xbb8310d486368db6bd6f849402fdd73ad53d316b5a
 // Sentinel for "no SAFE_NONCE override supplied".
 uint256 constant SAFE_NONCE_UNSET = type(uint256).max;
 
-/// @dev Returns true when `account` looks like a Safe wallet (exposes the Safe-specific `getThreshold()`).
-function _isSafeWallet(
+/// @dev Canonical Safe singleton (master copy) addresses. Safe singletons are deployed deterministically, so these
+/// are identical on every chain. A Safe proxy stores its singleton at storage slot 0, which lets us confirm an
+/// address is a genuine Safe proxy on-chain (used as a fallback when the Safe Transaction Service is unavailable).
+function _isKnownSafeSingleton(
+  address singleton
+) pure returns (bool) {
+  return singleton == 0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552 // GnosisSafe v1.3.0
+    || singleton == 0x3E5c63644E683549055b9Be8653de26E0B4CD36E // GnosisSafeL2 v1.3.0
+    || singleton == 0x41675C099F32341bf84BFc5382aF534df5C7461a // Safe v1.4.1
+    || singleton == 0x29fcB43b46531BcA003ddC8FCB67FFE91900C762; // SafeL2 v1.4.1
+}
+
+/// @dev On-chain Safe detection: reads the proxy's singleton from storage slot 0 and checks it against the known
+/// Safe singletons. Used only when the Safe Transaction Service cannot confirm the address (offline / unmapped chain).
+function _isSafeProxyOnchain(
   address account
 ) view returns (bool) {
-  (bool ok, bytes memory ret) = account.staticcall(abi.encodeWithSignature("getThreshold()"));
-  return ok && ret.length >= 32 && abi.decode(ret, (uint256)) != 0;
+  address singleton = address(uint160(uint256(vm.load(account, bytes32(uint256(0))))));
+  return _isKnownSafeSingleton(singleton);
 }
 
 /// @dev Safe Transaction Service base URL for `chainId`, or "" when unknown. The `SAFE_TX_SERVICE_URL` env var,
@@ -144,16 +157,17 @@ function _tryGetSafeApiNonce(
 
 /// @dev Resolves the Safe nonce used for hash computation, highest priority first:
 ///   1. `SAFE_NONCE` env var — overwrite an existing/queued nonce (e.g. to co-sign a specific pending tx)
-///   2. Safe Transaction Service `nonce` (queue-aware)
+///   2. Safe Transaction Service `nonce` (queue-aware) — passed in via `apiOk`/`apiNonce` to reuse the single API call
 ///   3. on-chain `Safe.nonce()`
-/// `safe` is assumed to be a Safe wallet, so the on-chain fallback always succeeds.
+/// `safe` is a confirmed Safe wallet, so the on-chain fallback always succeeds.
 function _resolveSafeNonce(
-  address safe
-) returns (uint256 nonce, string memory source) {
+  address safe,
+  bool apiOk,
+  uint256 apiNonce
+) view returns (uint256 nonce, string memory source) {
   uint256 overrideNonce = vm.envOr("SAFE_NONCE", SAFE_NONCE_UNSET);
   if (overrideNonce != SAFE_NONCE_UNSET) return (overrideNonce, "overwrite (env SAFE_NONCE)");
 
-  (bool apiOk, uint256 apiNonce) = _tryGetSafeApiNonce(safe);
   if (apiOk) return (apiNonce, "safe-tx-service api");
 
   (, bytes memory ret) = safe.staticcall(abi.encodeWithSignature("nonce()"));
@@ -192,10 +206,12 @@ function computeSafeTxHashes(
 
 /// @dev Computes and logs the Safe (Gnosis Safe) EIP-712 hashes for the pending transaction so signers can
 /// independently verify them (e.g. with `axieinfinity/safe-utils`, the Safe UI, or a hardware wallet) before signing.
-/// Silently returns when `safe` is not a Safe wallet. See `_resolveSafeNonce` for the nonce priority.
+/// Safe detection trusts the Safe Transaction Service (HTTP 200), falling back to the on-chain singleton check when
+/// the service is unavailable. Silently returns when `safe` is not a Safe. See `_resolveSafeNonce` for nonce priority.
 function logSafeTxHashes(address safe, address to, uint256 value, bytes memory data) {
-  if (!_isSafeWallet(safe)) return;
-  (uint256 nonce, string memory nonceSource) = _resolveSafeNonce(safe);
+  (bool apiOk, uint256 apiNonce) = _tryGetSafeApiNonce(safe);
+  if (!apiOk && !_isSafeProxyOnchain(safe)) return; // not a Safe per the service or on-chain singleton check
+  (uint256 nonce, string memory nonceSource) = _resolveSafeNonce(safe, apiOk, apiNonce);
 
   (bytes32 domainHash, bytes32 messageHash, bytes32 safeTxHash) =
     computeSafeTxHashes(block.chainid, safe, to, value, data, nonce);
@@ -227,6 +243,8 @@ function cheatBroadcast(address from, address to, uint256 callValue, bytes memor
   );
   console.log(StdStyle.cyan("Cast Decoded Call Data:"), decodedCallData);
   console.log("--------------------------------------------------------------------");
+
+  logSafeTxHashes({ safe: from, to: to, value: callValue, data: callData });
 
   logSafeTxHashes({ safe: from, to: to, value: callValue, data: callData });
 

--- a/test/SafeTxHashes.t.sol
+++ b/test/SafeTxHashes.t.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import { Test } from "../dependencies/forge-std-1.9.5/src/Test.sol";
+
+import { computeSafeTxHashes } from "script/utils/Helpers.sol";
+
+contract SafeTxHashesTest is Test {
+  // Reference values produced independently with `cast` using the same inputs as the assertions below
+  // (Safe 0x9D05...902a on Ronin mainnet chainId 2020, nonce 318, to 0x..bEEF, value 0, data 0x12345678).
+  // This guards against any transposition of fields / wrong typehash in `computeSafeTxHashes`.
+  function testConcrete_ComputeSafeTxHashes_MatchesCastReference() public pure {
+    (bytes32 domainHash, bytes32 messageHash, bytes32 safeTxHash) = computeSafeTxHashes({
+      chainId: 2020,
+      safe: 0x9D05D1F5b0424F8fDE534BC196FFB6Dd211D902a,
+      to: 0x000000000000000000000000000000000000bEEF,
+      value: 0,
+      data: hex"12345678",
+      nonce: 318
+    });
+
+    assertEq(domainHash, 0x7a5604929f746fb1dd6cb5b7884f41ced5033360310c6f96178720a156cf460c, "domain hash");
+    assertEq(messageHash, 0x8264c8c2d184f126c0ab043d4c8969ff36d393e3827b1949524718d2450c2781, "message hash");
+    assertEq(safeTxHash, 0x0a2b1abe236ee4c4b28f510d14fa5d704d74e1a3ba8093217834cc9d4b8b229f, "safe tx hash");
+  }
+}


### PR DESCRIPTION
When the broadcast sender is a Safe wallet, cheatBroadcast only logs and pranks instead of sending. Add Domain Hash, Message Hash, and Safe Tx Hash to that log so signers can independently verify before signing.

Nonce resolution priority: overwrite (env SAFE_NONCE) > Safe Transaction Service API (queue-aware) > on-chain Safe.nonce(). The API base URL maps chainId 2020 to the Ronin service and is overridable via SAFE_TX_SERVICE_URL.

Hash math is extracted to a pure computeSafeTxHashes() and verified against independently cast-derived reference values in test/SafeTxHashes.t.sol.

### Description

### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
